### PR TITLE
Also reset particle positions and ages, not just the texture

### DIFF
--- a/src/render/propagator.ts
+++ b/src/render/propagator.ts
@@ -152,6 +152,24 @@ export class ParticlePropagator {
     this.speedCurve = speedCurve
   }
 
+  resetBuffers(): void {
+    if (this.inputBuffers) this.inputBuffers.destroy()
+    if (this.outputBuffers) this.outputBuffers.destroy()
+
+    const gl = this.program.gl
+    this.inputBuffers = new ParticleBuffers(gl, this.numParticlesAllocate)
+    this.outputBuffers = new ParticleBuffers(gl, this.numParticlesAllocate)
+
+    // Initialise input buffer with random particle positions and ages.
+    const initialCoordinates = this.generateInitialParticleData()
+    const initialAges = this.generateInitialParticleAges()
+    this.inputBuffers.initialise(initialCoordinates, initialAges)
+
+    // Since we swap the buffers immediately in the update function, swap them
+    // here too.
+    this.swapBuffers()
+  }
+
   resetAges(): void {
     const initialAges = this.generateInitialParticleAges()
     // Set the new ages on the output buffer, since we swap the buffers at the
@@ -211,24 +229,6 @@ export class ParticlePropagator {
     // Re-enable the fragment shader and unbind the transform feedback.
     gl.disable(gl.RASTERIZER_DISCARD)
     gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null)
-  }
-
-  private resetBuffers(): void {
-    if (this.inputBuffers) this.inputBuffers.destroy()
-    if (this.outputBuffers) this.outputBuffers.destroy()
-
-    const gl = this.program.gl
-    this.inputBuffers = new ParticleBuffers(gl, this.numParticlesAllocate)
-    this.outputBuffers = new ParticleBuffers(gl, this.numParticlesAllocate)
-
-    // Initialise input buffer with random particle positions and ages.
-    const initialCoordinates = this.generateInitialParticleData()
-    const initialAges = this.generateInitialParticleAges()
-    this.inputBuffers.initialise(initialCoordinates, initialAges)
-
-    // Since we swap the buffers immediately in the update function, swap them
-    // here too.
-    this.swapBuffers()
   }
 
   private bindUniforms(dt: number): void {

--- a/src/visualiser.ts
+++ b/src/visualiser.ts
@@ -262,7 +262,7 @@ export class StreamlineVisualiser {
     }
     if (this._numParticles === numParticles) return
 
-    this.resetParticleTexture()
+    this.resetParticles()
 
     this._numParticles = numParticles
 
@@ -303,7 +303,7 @@ export class StreamlineVisualiser {
     velocityImage: VelocityImage,
     doResetParticles: boolean
   ): void {
-    if (doResetParticles) this.resetParticleTexture()
+    if (doResetParticles) this.resetParticles()
     this.updateVelocityImage(velocityImage)
   }
 
@@ -600,7 +600,10 @@ export class StreamlineVisualiser {
     this.textureRenderer?.swapBuffers()
   }
 
-  private resetParticleTexture(): void {
+  private resetParticles(): void {
+    // Reset particle positions and ages.
+    this.particlePropagator?.resetBuffers()
+    // Reset rendered particle textures.
     this.previousParticleTexture = this.createZeroTexture()
     this.currentParticleTexture = this.createZeroTexture()
     this.textureRenderer?.resetParticleTextures(


### PR DESCRIPTION
When setting a new velocity image (for example, when zooming or panning the map), the particle textures were reset, but the positions and ages were not. This led to weird "ghosts" of the previous zoom level being left behind when zooming in, especially when clearly defined features were present.