### PR TITLE
Add renderCopy to visualiser

### DIFF
--- a/src/visualiser.ts
+++ b/src/visualiser.ts
@@ -497,6 +497,25 @@ export class StreamlineVisualiser {
     this.swapParticleTextures()
   }
 
+  /**
+   * Re-draws the final composite pass with the current scaling, without
+   * advancing particles. Use this to render world copies at different offsets:
+   * call setScaling() with the shifted bbox, then renderCopy().
+   *
+   * Must be called after renderFrame() in the same frame. Uses
+   * previousParticleTexture because renderFrame() swaps textures at the end.
+   */
+  renderCopy(): void {
+    if (!this.isRendering) return
+    if (!this.finalRenderer || !this.previousParticleTexture) return
+
+    this.finalRenderer.render(this.previousParticleTexture, this.scaling)
+
+    if (this.spriteRenderer) {
+      this.spriteRenderer.render(this.particlePropagator!.buffers, this.scaling)
+    }
+  }
+
   private async compileShaderPrograms(): Promise<
     [ShaderProgram, ShaderProgram, ShaderProgram, ShaderProgram]
   > {


### PR DESCRIPTION
This is part of our solution to #29. Supporting world copies in the WMS layer would require more work there — we have a different data source, so we're using our own map layer implementation rather than this package's. But the one thing we couldn't get around was needing something in the visualiser to render the previous particle texture again.

Disclosure: we worked with Claude on this PR.