### PR TITLE
Add particle opacity to light/dark modes

### DIFF
--- a/examples/options.ts
+++ b/examples/options.ts
@@ -94,6 +94,12 @@ export class VisualiserOptionsControl extends HTMLElement {
       1,
       5
     )
+    const particleOverlayOpacityControl = this.createNumericOptionsControl(
+      'Particle overlay opacity',
+      'particleOverlayOpacity',
+      0.1,
+      1
+    )
     const aspectRatioControl = this.createTrailParticleAspectRatioControl()
     const doRotateParticlesControl = this.createTrailParticlesDoRotateControl()
     const trailParticleShapeControl = this.createTrailParticleShapeControl(
@@ -110,6 +116,7 @@ export class VisualiserOptionsControl extends HTMLElement {
     this.container.appendChild(maxAgeControl)
     this.container.appendChild(speedExponentControl)
     this.container.appendChild(growthRateControl)
+    this.container.appendChild(particleOverlayOpacityControl)
     this.container.appendChild(trailParticleShapeControl)
     this.container.appendChild(doRotateParticlesControl)
     this.container.appendChild(aspectRatioControl)

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -37,6 +37,7 @@ export interface WMSStreamlineLayerOptions {
   spriteUrl?: URL
   trailParticleOptions?: TrailParticleOptions
   transformRequest?: TransformRequestFunction
+  particleOverlayOpacity?: number
 }
 
 function convertMapBoundsToEpsg3857BoundingBox(
@@ -549,7 +550,8 @@ export class WMSStreamlineLayer implements CustomLayerInterface {
       speedExponent: options.speedExponent,
       particleColor: options.particleColor,
       spriteUrl: options.spriteUrl,
-      trailParticleOptions: options.trailParticleOptions
+      trailParticleOptions: options.trailParticleOptions,
+      particleOverlayOpacity: options.particleOverlayOpacity
     }
   }
 }

--- a/src/render/final.ts
+++ b/src/render/final.ts
@@ -21,6 +21,7 @@ export class FinalRenderer {
   private static readonly NUM_SEGMENTS_COLORMAP = 64
 
   public style: StreamlineStyle
+  public particleOverlayOpacity: number
 
   private program: ShaderProgram
   private positionBuffer: WebGLBuffer | null
@@ -34,10 +35,12 @@ export class FinalRenderer {
   constructor(
     program: ShaderProgram,
     style: StreamlineStyle,
-    colormap: Colormap
+    colormap: Colormap,
+    particleOverlayOpacity: number = 1.0
   ) {
     this.program = program
     this.style = style
+    this.particleOverlayOpacity = particleOverlayOpacity
     this.positionBuffer = null
     this.texCoordBuffer = null
     this.vertexArray = null
@@ -142,6 +145,13 @@ export class FinalRenderer {
     // Uniform to set the render style, its values correspond to the values
     // of the StreamlineStyle enum.
     gl.uniform1i(this.program.getUniformLocation('u_style'), this.style)
+
+    // Uniform to control the opacity of the particle overlay (used by
+    // LightParticlesOnMagnitude and DarkParticlesOnMagnitude styles).
+    gl.uniform1f(
+      this.program.getUniformLocation('u_particle_opacity'),
+      this.particleOverlayOpacity
+    )
 
     // Uniforms for the start and end of the colormap.
     gl.uniform1f(

--- a/src/shaders/final.frag.glsl
+++ b/src/shaders/final.frag.glsl
@@ -2,6 +2,7 @@
 precision highp float;
 
 uniform int u_style;
+uniform float u_particle_opacity;
 
 uniform sampler2D u_particle_texture;
 uniform sampler2D u_colormap_texture;
@@ -58,11 +59,11 @@ void main() {
             color = mix(
                 magnitude_color,
                 vec4(1.0, 1.0, 1.0, 1.0),
-                particle_color.a
+                particle_color.a * u_particle_opacity
             );
         } else if (u_style == 1) {
             // Render dark particles on velocity magnitude.
-            float factor = 1.0 - particle_color.a;
+            float factor = 1.0 - particle_color.a * u_particle_opacity;
             color = magnitude_color;
             color.rgb *= factor * 0.8 + 0.2;
         } else if (u_style == 2) {

--- a/src/visualiser.ts
+++ b/src/visualiser.ts
@@ -46,6 +46,7 @@ export interface StreamlineVisualiserOptions {
   particleColor?: string
   spriteUrl?: URL
   trailParticleOptions?: TrailParticleOptions
+  particleOverlayOpacity?: number
 }
 
 export function determineDoRotateParticles(
@@ -203,7 +204,8 @@ export class StreamlineVisualiser {
     this.finalRenderer = new FinalRenderer(
       programRenderFinal,
       this._options.style,
-      colormap
+      colormap,
+      this._options.particleOverlayOpacity
     )
 
     this.textureRenderer.initialise()
@@ -413,6 +415,8 @@ export class StreamlineVisualiser {
     }
 
     this.finalRenderer.style = this._options.style
+    this.finalRenderer.particleOverlayOpacity =
+      this._options.particleOverlayOpacity ?? 1.0
 
     const particleTexture = this.createParticleTexture()
     this.particleRenderer.setParticleTexture(particleTexture)


### PR DESCRIPTION
Adds a new option to the visualiser and WMS layer, `particleOverlayOpacity`, allowing semi-transparent particles when in the light and dark particle modes. This doesn't affect rendered sprites.